### PR TITLE
Compatibility with Symfony >=2.7

### DIFF
--- a/EventListener/CacheListener.php
+++ b/EventListener/CacheListener.php
@@ -2,7 +2,7 @@
 
 namespace M6Web\Bundle\DomainUserBundle\EventListener;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class CacheListener
@@ -12,17 +12,17 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 class CacheListener
 {
     protected $defaultCache;
-    protected $securityContext;
+    protected $tokenStorage;
 
     /**
      * Constructor
      *
-     * @param SecurityContextInterface $securityContext
-     * @param integer                  $defaultCache
+     * @param TokenStorageInterface $tokenStorage
+     * @param integer               $defaultCache
      */
-    public function __construct(SecurityContextInterface $securityContext, $defaultCache)
+    public function __construct(TokenStorageInterface $tokenStorage, $defaultCache)
     {
-        $this->securityContext = $securityContext;
+        $this->tokenStorage = $tokenStorage;
         $this->defaultCache    = $defaultCache;
     }
 
@@ -41,7 +41,7 @@ class CacheListener
             return;
         }
 
-        $token = $this->securityContext->getToken();
+        $token = $this->tokenStorage->getToken();
         if ($token === null) {
             return;
         }

--- a/EventListener/UserAccessListener.php
+++ b/EventListener/UserAccessListener.php
@@ -5,8 +5,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\Security\Core\SecurityContext;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class FirewallListener
@@ -15,16 +14,16 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  */
 class UserAccessListener
 {
-    protected $context;
+    protected $tokenStorage;
 
     /**
      * Constructor
      *
-     * @param SecurityContextInterface $context
+     * @param TokenStorageInterface $tokenStorage
      */
-    public function __construct(SecurityContextInterface $context)
+    public function __construct(TokenStorageInterface $tokenStorage)
     {
-        $this->context = $context;
+        $this->tokenStorage = $tokenStorage;
     }
 
     /**
@@ -39,7 +38,7 @@ class UserAccessListener
         if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
             return;
         }
-        $token = $this->context->getToken();
+        $token = $this->tokenStorage->getToken();
         if ($token === null) {
             return;
         }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,7 +13,7 @@ services:
     m6_web_domain_user.security.authentication_listener:
         class:  M6Web\Bundle\DomainUserBundle\Security\FirewallListener
         arguments:
-            - "@security.context"
+            - "@security.token_storage"
             - "@security.authentication.manager"
             - "@router.request_context"
             - "%m6_web_domain_user.default_user%"
@@ -23,10 +23,10 @@ services:
             class: M6Web\Bundle\DomainUserBundle\EventListener\UserAccessListener
             tags:
               - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority:-255 }
-            arguments: [@security.context]
+            arguments: [@security.token_storage]
 
     m6_web_domain_user.cache_listener:
             class: M6Web\Bundle\DomainUserBundle\EventListener\CacheListener
             tags:
               - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority:255 }
-            arguments: [@security.context, "%m6_web_domain_user.default_cache%"]
+            arguments: [@security.token_storage, "%m6_web_domain_user.default_cache%"]

--- a/Security/FirewallListener.php
+++ b/Security/FirewallListener.php
@@ -9,7 +9,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
-use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class FirewallListener
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  */
 class FirewallListener implements ListenerInterface
 {
-    protected $securityContext;
+    protected $tokenStorage;
     protected $authenticationManager;
     protected $requestContext;
     protected $defaultUsername;
@@ -27,20 +27,20 @@ class FirewallListener implements ListenerInterface
     /**
      * Constructor
      *
-     * @param SecurityContextInterface       $securityContext
+     * @param TokenStorageInterface          $tokenStorage
      * @param AuthenticationManagerInterface $authenticationManager
      * @param RequestContext                 $requestContext
      * @param string                         $defaultUsername
      * @param string                         $routerParameter
      */
     public function __construct(
-        SecurityContextInterface $securityContext,
+        TokenStorageInterface $tokenStorage,
         AuthenticationManagerInterface $authenticationManager,
         RequestContext $requestContext,
         $defaultUsername,
         $routerParameter)
     {
-        $this->securityContext       = $securityContext;
+        $this->tokenStorage          = $tokenStorage;
         $this->authenticationManager = $authenticationManager;
         $this->requestContext        = $requestContext;
         $this->defaultUsername       = $defaultUsername;
@@ -68,7 +68,7 @@ class FirewallListener implements ListenerInterface
         $token = new Token($username);
         try {
             $authenticatedToken = $this->authenticationManager->authenticate($token);
-            $this->securityContext->setToken($authenticatedToken);
+            $this->tokenStorage->setToken($authenticatedToken);
         } catch (AuthenticationException $e) {
             throw new AccessDeniedException($e->getMessage(), $e);
         }

--- a/Tests/Units/Security/FirewallListener.php
+++ b/Tests/Units/Security/FirewallListener.php
@@ -24,8 +24,8 @@ class FirewallListener extends test
 
     public function testHandleWithClient()
     {
-        $securityContext = new \mock\Symfony\Component\Security\Core\SecurityContextInterface();
-        $authManager     = new \mock\Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface();
+        $tokenStorage = new \mock\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface();
+        $authManager  = new \mock\Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface();
         $authManager->getMockController()->authenticate = function (TokenInterface $token) {
             if (in_array($token->getUsername(), ['android', 'default'])) {
                 return new Token($token->getUsername(), ['ROLE_USER']);
@@ -34,7 +34,7 @@ class FirewallListener extends test
         };
         $requestContext  = new \mock\Symfony\Component\Routing\RequestContext();
 
-        $listener = new TestedClass($securityContext, $authManager, $requestContext, 'default', 'client');
+        $listener = new TestedClass($tokenStorage, $authManager, $requestContext, 'default', 'client');
 
         $this->getMockGenerator()->orphanize('__construct');
         $event = new \mock\Symfony\Component\HttpKernel\Event\GetResponseEvent();
@@ -43,7 +43,7 @@ class FirewallListener extends test
         $listener->handle($event);
 
         $this
-            ->mock($securityContext)
+            ->mock($tokenStorage)
                 ->call('setToken')
                     ->withArguments(new Token('android', ['ROLE_USER']))
                     ->once()
@@ -55,7 +55,7 @@ class FirewallListener extends test
 
     public function testHandleWithDefault()
     {
-        $securityContext = new \mock\Symfony\Component\Security\Core\SecurityContextInterface();
+        $tokenStorage = new \mock\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface();
         $authManager     = new \mock\Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface();
         $authManager->getMockController()->authenticate = function (TokenInterface $token) {
             if (in_array($token->getUsername(), ['android', 'default'])) {
@@ -65,7 +65,7 @@ class FirewallListener extends test
         };
         $requestContext  = new \mock\Symfony\Component\Routing\RequestContext();
 
-        $listener = new TestedClass($securityContext, $authManager, $requestContext, 'default', 'client');
+        $listener = new TestedClass($tokenStorage, $authManager, $requestContext, 'default', 'client');
 
         $this->getMockGenerator()->orphanize('__construct');
         $event = new \mock\Symfony\Component\HttpKernel\Event\GetResponseEvent();
@@ -74,7 +74,7 @@ class FirewallListener extends test
         $listener->handle($event);
 
         $this
-            ->mock($securityContext)
+            ->mock($tokenStorage)
                 ->call('setToken')
                     ->withArguments(new Token('default', ['ROLE_USER']))
                     ->once()
@@ -86,7 +86,7 @@ class FirewallListener extends test
 
     public function testHandleWithoutParam()
     {
-        $securityContext = new \mock\Symfony\Component\Security\Core\SecurityContextInterface();
+        $tokenStorage = new \mock\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface();
         $authManager     = new \mock\Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface();
         $authManager->getMockController()->authenticate = function (TokenInterface $token) {
             if (in_array($token->getUsername(), ['android', 'default'])) {
@@ -96,7 +96,7 @@ class FirewallListener extends test
         };
         $requestContext  = new \mock\Symfony\Component\Routing\RequestContext();
 
-        $listener = new TestedClass($securityContext, $authManager, $requestContext, 'default', 'client');
+        $listener = new TestedClass($tokenStorage, $authManager, $requestContext, 'default', 'client');
 
         $this->getMockGenerator()->orphanize('__construct');
         $event = new \mock\Symfony\Component\HttpKernel\Event\GetResponseEvent();
@@ -105,7 +105,7 @@ class FirewallListener extends test
         $listener->handle($event);
 
         $this
-            ->mock($securityContext)
+            ->mock($tokenStorage)
                 ->call('setToken')
                     ->withArguments(new Token('default', ['ROLE_USER']))
                     ->once()
@@ -116,7 +116,7 @@ class FirewallListener extends test
 
     public function testHandleWithBadClient()
     {
-        $securityContext = new \mock\Symfony\Component\Security\Core\SecurityContextInterface();
+        $tokenStorage = new \mock\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface();
         $authManager     = new \mock\Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface();
         $authManager->getMockController()->authenticate = function (TokenInterface $token) {
             if (in_array($token->getUsername(), ['android', 'default'])) {
@@ -126,7 +126,7 @@ class FirewallListener extends test
         };
         $requestContext  = new \mock\Symfony\Component\Routing\RequestContext();
 
-        $listener = new TestedClass($securityContext, $authManager, $requestContext, 'default', 'client');
+        $listener = new TestedClass($tokenStorage, $authManager, $requestContext, 'default', 'client');
 
         $this->getMockGenerator()->orphanize('__construct');
         $event = new \mock\Symfony\Component\HttpKernel\Event\GetResponseEvent();
@@ -135,7 +135,7 @@ class FirewallListener extends test
         $this
             ->exception(function () use ($listener, $event) { $listener->handle($event); })
                 ->isInstanceOf('Symfony\Component\Security\Core\Exception\AccessDeniedException')
-            ->mock($securityContext)
+            ->mock($tokenStorage)
                 ->call('setToken')
                     ->never();
     }

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "m6web/firewall-bundle": "0.3.*"
     },
     "require-dev": {
-        "symfony/symfony": "~2.3",
+        "symfony/symfony": "~2.7",
         "atoum/atoum": "dev-master"
     }
 }


### PR DESCRIPTION
SecurityContext is now deprecated, replaced by TokenStorage.

A new major version.

http://symfony.com/blog/new-in-symfony-2-6-security-component-improvements