### PR TITLE
Fix : send an http 403 error instead of 500 when user not found

### DIFF
--- a/Security/FirewallListener.php
+++ b/Security/FirewallListener.php
@@ -2,11 +2,10 @@
 
 namespace M6Web\Bundle\DomainUserBundle\Security;
 
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Firewall\ListenerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
@@ -70,7 +69,7 @@ class FirewallListener implements ListenerInterface
             $authenticatedToken = $this->authenticationManager->authenticate($token);
             $this->tokenStorage->setToken($authenticatedToken);
         } catch (AuthenticationException $e) {
-            throw new AccessDeniedException($e->getMessage(), $e);
+            throw new AccessDeniedHttpException($e->getMessage());
         }
     }
 }

--- a/Tests/Units/Security/FirewallListener.php
+++ b/Tests/Units/Security/FirewallListener.php
@@ -134,7 +134,7 @@ class FirewallListener extends test
 
         $this
             ->exception(function () use ($listener, $event) { $listener->handle($event); })
-                ->isInstanceOf('Symfony\Component\Security\Core\Exception\AccessDeniedException')
+                ->isInstanceOf('Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException')
             ->mock($tokenStorage)
                 ->call('setToken')
                     ->never();


### PR DESCRIPTION
In some case an internal server error(500) is send by symfony when a user is not found.
This pr fix this, symfony return a forbidden(403) when user was not found
