### PR TITLE
Allow profiler routes.

### DIFF
--- a/EventListener/UserAccessListener.php
+++ b/EventListener/UserAccessListener.php
@@ -68,6 +68,11 @@ class UserAccessListener
             $allowed = $allowConfig['routes'][$route];
         }
 
+        // 4. Override if profiler
+        if (preg_match('/^_(wdt|profiler)/', $route)) {
+            $allowed = true;
+        }
+
         if (!$allowed) {
             throw new AccessDeniedHttpException("Access denied");
         }


### PR DESCRIPTION
## Pourquoi

En dev on a des `ForbiddenException` quand on essaye de se connecter au profiler avec des users qui ont des droits restreints sur certaines routes.

## Comment

En autorisant quoi qui arrive les routes du profiler.