### PR TITLE
Compatibility with Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,27 @@
+sudo: false
+
 language: php
 
 php:
-  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+
+env:
+  - SYMFONY_VERSION="~2.7.0"
+  - SYMFONY_VERSION="~3.0.0"
+  - SYMFONY_VERSION="~3.1.0"
+
+before_install:
+  - phpenv config-rm xdebug.ini
+
+install:
+  - composer install -n
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev
+  - composer require --dev --no-update symfony/symfony:${SYMFONY_VERSION}
+  - composer update --prefer-dist --no-interaction
 
 script:
   - vendor/bin/atoum
+

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -24,11 +24,11 @@ services:
         tags:
           - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority:-255 }
         arguments:
-            - "@security.context"
+            - "@security.token_storage"
             - "%m6_web_domain_user.allow_debug_route%"
 
     m6_web_domain_user.cache_listener:
         class: M6Web\Bundle\DomainUserBundle\EventListener\CacheListener
         tags:
           - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority:255 }
-        arguments: [@security.token_storage, "%m6_web_domain_user.default_cache%"]
+        arguments: ["@security.token_storage", "%m6_web_domain_user.default_cache%"]


### PR DESCRIPTION
Replaces `security.context` by `security.token_storage`

`M6Web\Bundle\DomainUserBundle\EventListener\UserAccessListener` already has the correct type hint.