### PR TITLE
use a mandatory cache warmer to create the users config in the sf cache

### DIFF
--- a/Cache/Warmup.php
+++ b/Cache/Warmup.php
@@ -1,0 +1,94 @@
+<?php
+
+
+namespace M6Web\Bundle\DomainUserBundle\Cache;
+
+use M6Web\Bundle\DomainUserBundle\User\UserProvider;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmer;
+use Symfony\Component\Finder\Finder;
+
+class Warmup extends CacheWarmer
+{
+    const CACHEFILE = 'DomainUserConfig.php';
+
+    /**
+     * @var UserProvider;
+     */
+    protected $userProvider;
+
+    /**
+     * @var string
+     */
+    protected $userdir;
+
+    /**
+     * {@inheritDoc}
+     *
+     */
+    public function warmUp($cacheDir)
+    {
+        if (!is_dir($this->userdir)) {
+            throw new \InvalidArgumentException('userdir is not a directory : '.print_r($this->userdir, true).'given');
+        }
+
+        $finder = new Finder();
+        $finder->files()->in($this->userdir)->name('*.yml');
+        $users = [];
+        foreach($finder as $file) {
+            $user = basename($file, '.yml');
+            $export_user = var_export($this->userProvider->getUserByUserName($user), true);
+            $code = <<<EOF
+<?php
+
+/**
+* This code has been auto-generated
+* by the M6Web Domain User Bundle
+* 
+*/
+
+return \$user = {$export_user};
+
+EOF;
+            $this->writeCacheFile(self::getCachePath($cacheDir, $user), $code);
+        }
+    }
+
+    public static function getCachePath($cacheDir, $username)
+    {
+        return $cacheDir.'/DomainUserConfig_'.$username.'.php';
+    }
+
+    /**
+     * @param string $dir
+     *
+     * @return $this
+     */
+    public function setUserDir($dir)
+    {
+        $this->userdir = $dir;
+        return $this;
+    }
+
+    /**
+     * @param $p UserProvider
+     *
+     * @return $this
+     */
+    public function setUserProvider($p)
+    {
+        $this->userProvider = $p;
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return bool
+     */
+    public function isOptional()
+    {
+        return false; // this warmup is not optionnal
+    }
+
+
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,9 +28,10 @@ class Configuration implements ConfigurationInterface
             ->arrayNode('firewall')
                 ->addDefaultsIfNotSet()
                 ->children()
-                    ->booleanNode('allow_debug_route')->defaultFalse()->end();
-
+                    ->booleanNode('allow_debug_route')->defaultFalse()->end()
+                ->end()
+            ->end()
+            ;
         return $treeBuilder;
     }
-
 }

--- a/DependencyInjection/M6WebDomainUserExtension.php
+++ b/DependencyInjection/M6WebDomainUserExtension.php
@@ -3,6 +3,7 @@
 namespace M6Web\Bundle\DomainUserBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,7 +1,7 @@
 services:
     m6_web_domain_user.user_provider:
         class: M6Web\Bundle\DomainUserBundle\User\UserProvider
-        arguments: ["@m6_web_domain_user.user_provider.yamlparser", "%m6_web_domain_user.users_dir%"]
+        arguments: ["@m6_web_domain_user.user_provider.yamlparser", "%m6_web_domain_user.users_dir%", "%kernel.cache_dir%"]
 
     m6_web_domain_user.user_provider.yamlparser:
         class: Symfony\Component\Yaml\Parser
@@ -32,3 +32,12 @@ services:
         tags:
           - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse, priority:255 }
         arguments: ["@security.token_storage", "%m6_web_domain_user.default_cache%"]
+
+    # config cache warmer
+    m6_web_domain_user.config_cache_warmer:
+        class: M6Web\Bundle\DomainUserBundle\Cache\Warmup
+        calls:
+          - [ "setUserDir", ["%m6_web_domain_user.users_dir%"] ]
+          - [ "setUserProvider", ["@m6_web_domain_user.user_provider"] ]
+        tags:
+          - { name: kernel.cache_warmer, priority: 0 }

--- a/Tests/Units/User/UserProvider.php
+++ b/Tests/Units/User/UserProvider.php
@@ -24,18 +24,18 @@ class UserProvider extends test
     public function testLoadUserByUsername()
     {
         $parser   = new \Symfony\Component\Yaml\Parser();
-        $provider = new TestedClass($parser, __DIR__.'/../../Fixtures/users/');
+        $provider = new TestedClass($parser, __DIR__.'/../../Fixtures/users/', '/tmp');
 
         $processor = new Processor();
 
         $this
-            ->object($user = $provider->loadUserByUsername('user1'))
+            ->object($user = $provider->getUserByUserName('user1'))
                 ->isInstanceOf('M6Web\Bundle\DomainUserBundle\User\User')
                 ->isEqualTo(new User('user1', $processor->processConfiguration(new UserConf(), [[]])))
-            ->object($user = $provider->loadUserByUsername('user2'))
+            ->object($user = $provider->getUserByUserName('user2'))
                 ->isInstanceOf('M6Web\Bundle\DomainUserBundle\User\User')
                 ->isEqualTo(new User('user2', $processor->processConfiguration(new UserConf(), [$parser->parse(file_get_contents(__DIR__.'/../../Fixtures/users/user2.yml'))])))
-            ->exception(function () use ($provider) { $provider->loadUserByUsername('unknownuser'); })
+            ->exception(function () use ($provider) { $provider->getUserByUserName('unknownuser'); })
                 ->isInstanceOf('Symfony\Component\Security\Core\Exception\UsernameNotFoundException');
     }
 }

--- a/User/User.php
+++ b/User/User.php
@@ -98,4 +98,15 @@ class User implements UserInterface
     {
         return $this->config['parameters'];
     }
+
+    /**
+     * @link http://php.net/manual/fr/language.oop5.magic.php#object.set-state
+     * @param array $vars
+     *
+     * @return User
+     */
+    public static function __set_state(array $vars)
+    {
+        return new User($vars['username'], $vars['config']);
+    }
 }

--- a/User/UserProvider.php
+++ b/User/UserProvider.php
@@ -2,12 +2,13 @@
 
 namespace M6Web\Bundle\DomainUserBundle\User;
 
+use M6Web\Bundle\DomainUserBundle\User\User;
+use M6Web\Bundle\DomainUserBundle\Cache\Warmup;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Yaml\Parser as YamlParser;
-
 
 /**
  * Class UserProvider
@@ -20,15 +21,27 @@ class UserProvider implements UserProviderInterface
     protected $usersDir;
 
     /**
+     * @var integer
+     */
+    protected $ttl;
+
+    /**
+     * @var string
+     */
+    protected $kernelCacheDir;
+
+    /**
      * Constructor
      *
      * @param YamlParser $yamlParser
      * @param string     $usersDir
+     * @param string     $kernelCacheDir
      */
-    public function __construct(YamlParser $yamlParser, $usersDir)
+    public function __construct(YamlParser $yamlParser, $usersDir, $kernelCacheDir)
     {
-        $this->yamlParser = $yamlParser;
-        $this->usersDir   = $usersDir;
+        $this->yamlParser     = $yamlParser;
+        $this->usersDir       = $usersDir;
+        $this->kernelCacheDir = $kernelCacheDir;
     }
 
     /**
@@ -36,12 +49,23 @@ class UserProvider implements UserProviderInterface
      */
     public function loadUserByUsername($username)
     {
+        return require Warmup::getCachePath($this->kernelCacheDir, $username);
+    }
+
+    /**
+     * process the yaml file a create a user object
+     *
+     * @param $username
+     *
+     * @return \M6Web\Bundle\DomainUserBundle\User\User
+     */
+    public function getUserByUserName($username)
+    {
         $file = sprintf('%s/%s.yml', $this->usersDir, $username);
         if (!file_exists($file)) {
             throw new UsernameNotFoundException(sprintf('User "%s" not found', $username));
         }
-        $userConfig = $this->yamlParser->parse(file_get_contents($file));
-
+        $userConfig             = $this->yamlParser->parse(file_get_contents($file)); // parse yaml file
         $processor              = new Processor();
         $processedConfiguration = $processor->processConfiguration(new UserConfiguration(), [$userConfig]);
 


### PR DESCRIPTION
a cache file will be created during the cache warmup (usually the cleanup phase). The cache file will be required at each request to retrieve the User object instead of creating it each time from the yaml file.

The warmer is mandatory. 