### PR TITLE
Use CacheListener only for master requests

### DIFF
--- a/EventListener/CacheListener.php
+++ b/EventListener/CacheListener.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace M6Web\Bundle\DomainUserBundle\EventListener;
+
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -35,6 +36,10 @@ class CacheListener
      */
     public function onKernelResponse(FilterResponseEvent $event)
     {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
         $response = $event->getResponse();
         $request  = $event->getRequest();
         if ($request->getMethod() !== 'GET' || !$response->isSuccessful() || $response->headers->hasCacheControlDirective('max-age')) {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "m6web/firewall-bundle": "0.3.*|^1.0.0"
     },
     "require-dev": {
-        "symfony/symfony": "~2.7|3.0",
+        "symfony/symfony": "~2.7|~3.0",
         "atoum/atoum": "^2.7"
     }
 }


### PR DESCRIPTION
## Why
Because, without this check, cache headers were set even on Http Exceptions.

=> Symfony catch HttpException and re-handle a subrequest with status code "200", so `$response->isSuccessful`, so cache headers were set on subrequest->response which is use to set the final request->response.

## Bonus
Fixing symfony3.0 strict requirement -> we should allow to use SF3.0+ (even if require-dev only)