### PR TITLE
Update to newer atoum versions

### DIFF
--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once __DIR__.'/vendor/autoload.php';

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 env:
   - SYMFONY_VERSION="~2.7.0"

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
     },
     "require-dev": {
         "symfony/symfony": "~2.7|~3.0",
-        "atoum/atoum": "^2.7"
+        "atoum/atoum": "^2.8|^3.0"
     }
 }


### PR DESCRIPTION
atoum 2.8 allows us to remove the bootstrap when it's only used to
require the autoloader (see atoum/atoum#605)

atoum 3.0 allows us to run tests on latest PHP versions.