### PR TITLE
 chore(sf): Improve sf4 compatibility and drop php 5.5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1

--- a/Cache/Warmup.php
+++ b/Cache/Warmup.php
@@ -4,8 +4,8 @@
 namespace M6Web\Bundle\DomainUserBundle\Cache;
 
 use M6Web\Bundle\DomainUserBundle\User\UserProvider;
-use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmer;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmer;
 
 class Warmup extends CacheWarmer
 {
@@ -32,10 +32,10 @@ class Warmup extends CacheWarmer
         }
 
         $finder = new Finder();
-        $finder->files()->in($this->userdir)->name('*.yml');
+        $finder->files()->in($this->userdir)->name(['*.yml', '*.yaml']);
         $users = [];
         foreach($finder as $file) {
-            $user = basename($file, '.yml');
+            $user = basename($file, pathinfo($file, PATHINFO_EXTENSION));
             $export_user = var_export($this->userProvider->getUserByUserName($user), true);
             $code = <<<EOF
 <?php


### PR DESCRIPTION
Sf4 suggest to use `*.yaml` instead of `*.yml`